### PR TITLE
Add an 'initial_only' setting to restrict on-open backups to first one

### DIFF
--- a/Automatic Backups.sublime-settings
+++ b/Automatic Backups.sublime-settings
@@ -11,6 +11,7 @@
 
     // If true, also save a backup copy any time a file is opened
     "backup_on_open_file": false,
+    "backup_on_open__initial_only": false,
 
     // External command to execute when Merge command is used (Ctrl+Alt+Shift+M by default).
     "backup_merge_command": ""

--- a/AutomaticBackups.py
+++ b/AutomaticBackups.py
@@ -30,9 +30,19 @@ class AutomaticBackupsEventListener(sublime_plugin.EventListener):
 
     def on_load(self, view):
         """When a file is opened, put a copy of the file into the
-        backup directory if backup_on_open_file setting is true."""
+        backup directory if backup_on_open_file setting is true. Optionally, 
+        only perform backup on open initially (ie no backups yet exists) by 
+        setting backup_on_open__initial_only to true."""
+
         settings = get_settings()
+
         if settings.get('backup_on_open_file', False):
+            if settings.get('backup_on_open__initial_only', False):
+                nav.find_backups(view)
+                if nav.found_backup_files:
+                    print ("Backup not saved, 'backup_on_open__initial_only' is"
+                           " true and a backup already exists.")
+                    return
             self.save_view_to_backup(view)
 
     def save_view_to_backup(self, view):


### PR DESCRIPTION
Hi there! 

This is my first pull-request... 

I love Automatic backups, it's so handy! However, I wanted to add the ability to only save on-open the first time. For instance, if I open an .ini file, I'd like to have it's original state backed up, but from then on, only backup that changes that I have made.

Cheers! 